### PR TITLE
Don't run jenkins jobs on catalina

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,11 @@ getApproval()
 
 pipeline {
   agent {
-    label 'x86_64&&brew&&macOS'
+    label 'x86_64&&brew&&macOS && !macOS_10_15'  // xdoc doesn't work on Catalina
   }
   environment {
     REPO = 'lib_spdif'
-    VIEW = "${env.JOB_NAME.contains('PR-') ? REPO+'_'+env.CHANGE_TARGET : REPO+'_'+env.BRANCH_NAME}"
+    VIEW = getViewName(REPO)
   }
   options {
     skipDefaultCheckout()


### PR DESCRIPTION
First spotted and discussion: https://github.com/xmos/lib_flash_data_partition/pull/63

xdoc and catalina do not mix well. xdoc is no longer being maintained.