### PR TITLE
removed print include in lib source

### DIFF
--- a/lib_spdif/src/SpdifTransmit.xc
+++ b/lib_spdif/src/SpdifTransmit.xc
@@ -10,7 +10,6 @@
  */
 
 #include <xs1.h>
-#include <print.h>
 #include <xclib.h>
 #include "assert.h"
 #include "spdif.h"


### PR DESCRIPTION
removed inclusion of print in spdifTransmit.xc as it is un-used and can cause build issues if xscope isn't used elsewhere in the program