### PR TITLE
Preamble counting to handle change of sample rate on incoming stream

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ UNRELEASED
   * ADDED:     Support for transmit at 32kHz
   * RESOLVED:  Coding optimisations not properly enabled in receiver
   * RESOLVED:  Receiver timing issues for sample rates greater than 96kHz
+  * RESOLVED:  Failure to select correct receive sample rate when the sample
+    rate of the incoming stream changes
 
 6.0.0
 -----


### PR DESCRIPTION
Authored by Joe.

Manually tested with the spdif_to_analogue example app and can no longer reproduce any situations where the receiver fails to select the correct sample rate after a change of sample rate on the incoming stream.

Also I've run lots of repeats of the USB Audio spdif_input test on the xcore-200 MCAB and can't reproduce the "zero channels" failures (the assumption being that the Mac host was reporting the device as having no channels because the clock wasn't valid - because the S/PDIF receiver had locked onto the wrong sample rate).