### PR TITLE
Use lib_sw_pll in setup code of example applications

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 lib_spdif Change Log
 ====================
 
+UNRELEASED
+----------
+
+  * CHANGED:   Use lib_sw_pll for configuring the application PLL in examples
+
 6.1.0
 -----
 

--- a/examples/app_spdif_loopback/Makefile
+++ b/examples/app_spdif_loopback/Makefile
@@ -22,7 +22,7 @@ XCC_FLAGS = -O3 -g
 
 # The USED_MODULES variable lists other module used by the application.
 
-USED_MODULES = lib_spdif lib_xassert
+USED_MODULES = lib_spdif lib_sw_pll lib_xassert
 
 
 #=============================================================================

--- a/examples/app_spdif_tx_example/Makefile
+++ b/examples/app_spdif_tx_example/Makefile
@@ -22,7 +22,7 @@ XCC_FLAGS = -O2 -g
 
 # The USED_MODULES variable lists other module used by the application.
 
-USED_MODULES = lib_spdif lib_xassert
+USED_MODULES = lib_spdif lib_sw_pll lib_xassert
 
 
 #=============================================================================

--- a/lib_spdif/src/SpdifTransmit.xc
+++ b/lib_spdif/src/SpdifTransmit.xc
@@ -1,4 +1,4 @@
-// Copyright 2011-2023 XMOS LIMITED.
+// Copyright 2011-2024 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 /**


### PR DESCRIPTION
Updated all the examples that need use the application PLL, and tested them on the bench to ensure they still work correctly.