### PR TITLE
Use terminate_flag instead of os._exit to terminate the threads

### DIFF
--- a/tests/spdif_test_utils.py
+++ b/tests/spdif_test_utils.py
@@ -79,7 +79,7 @@ class Spdif_rx(Clock):
             if in_buff[:8] == PREAMBLE_Y:
                 sample_counter += 1
                 if sample_counter >= self._no_of_samples:
-                    self.terminate_flag = True
+                    self.terminate()
 
 
 #####
@@ -135,15 +135,8 @@ class Spdif_tx(Clock):
             # TODO: make this delay random
             delay = 35e12
 
-        while True:
-            if self._terminate_thread:
-                self.terminate_flag = True
-
     def trigger_thread(self):
         self._trigger_thread = True
-
-    def terminate_thread(self):
-        self._terminate_thread = True
 
 
 #####
@@ -231,7 +224,7 @@ class Port_monitor(SimThread):
 
         if result:
             print("PASS")
-        self._spdif_tx.trigger_thread()
+        self.terminate()
 
 
 #####

--- a/tests/spdif_test_utils.py
+++ b/tests/spdif_test_utils.py
@@ -104,6 +104,7 @@ class Spdif_tx(Clock):
         )
         self._trigger_pin = trigger_pin  # If provided with a pin it will wait for a ready signal from the xe before transmitting
         self._trigger_thread = False  # Other simthreads can call the trigger() method to signal to this thread to change stream
+        self._terminate_thread = False
 
     def run(self):
         # Drives the bit representation of the signal byte-array, repeating forever, until the thread trigger is set
@@ -134,8 +135,15 @@ class Spdif_tx(Clock):
             # TODO: make this delay random
             delay = 35e12
 
+        while True:
+            if self._terminate_thread:
+                self.terminate_flag = True
+
     def trigger_thread(self):
         self._trigger_thread = True
+
+    def terminate_thread(self):
+        self._terminate_thread = True
 
 
 #####
@@ -223,7 +231,7 @@ class Port_monitor(SimThread):
 
         if result:
             print("PASS")
-        self.terminate_flag = True
+        self._spdif_tx.trigger_thread()
 
 
 #####

--- a/tests/spdif_test_utils.py
+++ b/tests/spdif_test_utils.py
@@ -79,7 +79,7 @@ class Spdif_rx(Clock):
             if in_buff[:8] == PREAMBLE_Y:
                 sample_counter += 1
                 if sample_counter >= self._no_of_samples:
-                    os._exit(os.EX_OK)
+                    self.terminate_flag = True
 
 
 #####
@@ -223,7 +223,7 @@ class Port_monitor(SimThread):
 
         if result:
             print("PASS")
-        os._exit(os.EX_OK)
+        self.terminate_flag = True
 
 
 #####


### PR DESCRIPTION
The spdif tx tests fail on MacOS with prints missing for the last few frames when the Spdif_rx.run() terminates with os._exit.
Terminating it by setting the SimThread::terminate_flag to True makes the prints get rendered properly and the tests pass.